### PR TITLE
5 view individual article

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.7.1",
         "react-router-dom": "^6.8.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -14251,6 +14252,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "axios": "^1.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.7.1",
     "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,55 @@
+:root {
+  --primary: #5a0001;
+  --secondary: #f6e8ea;
+  --other: #f45b69;
+  --primary-text: #b6b6b6;
+  --secondary-text: #22181c;
+}
+
+.header {
+  background-color: var(--primary);
+  color: var(--primary-text);
+}
+
+ul {
+  padding: 0;
+  list-style-type: none;
+}
+
+.article-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: 1px solid var(--primary-text);
+  border-radius: 0.5rem;
+  margin: 1rem;
+  background-color: var(--secondary);
+  color: var(--text);
+}
+
+.article-votes-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 0 1rem 0;
+  background-color: var(--other);
+}
+
+.article-topic-title-created-container {
+  display: flex;
+  transform: ;
+  padding: 0 1rem 0 1rem;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+  background-color: var(--primary);
+  color: var(--primary-text);
+}
+
+.article-author-comments-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -6,9 +6,53 @@
   --secondary-text: #22181c;
 }
 
+/* MAIN CONTAINERS */
+
+.App {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr 0.5fr;
+
+  gap: 1rem;
+  grid-template-areas:
+    "header header header"
+    "content content sidebar"
+    "content content sidebar";
+}
+
 .header {
+  grid-area: header;
   background-color: var(--primary);
   color: var(--primary-text);
+  height: 6rem;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  background-color: var(--secondary);
+  color: var(--secondary-text);
+  border-top-left-radius: 0.5rem;
+  padding: 1rem;
+  text-transform: capitalize;
+}
+
+[type="checkbox"] {
+  width: 2.5rem;
+  height: 2.5rem;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+.content {
+  grid-area: content;
+  text-align: center;
+  text-transform: capitalize;
+}
+
+.content > * {
+  margin: 0;
 }
 
 ul {
@@ -16,40 +60,89 @@ ul {
   list-style-type: none;
 }
 
+/* SINGLE ARTICLE */
+
 .article-container {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  border: 1px solid var(--primary-text);
-  border-radius: 0.5rem;
-  margin: 1rem;
-  background-color: var(--secondary);
-  color: var(--text);
+  justify-content: center;
+  padding-bottom: 3rem;
 }
 
-.article-votes-container {
+.article-vote-container {
+  background-color: var(--secondary);
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+  color: var(--primary);
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem 0 1rem 0;
-  background-color: var(--other);
+  justify-content: start;
+  padding: 0.2rem 0.2rem 0 0.2rem;
 }
 
-.article-topic-title-created-container {
+.article-content-container {
   display: flex;
-  transform: ;
-  padding: 0 1rem 0 1rem;
+  flex-direction: column;
+  justify-content: center;
+  background-color: var(--other);
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+  padding: 1rem;
+  width: 800px;
+}
+
+.article-content-title-container {
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
-  background-color: var(--primary);
-  color: var(--primary-text);
 }
 
-.article-author-comments-container {
+.article-content-title-container > * {
+  margin: 0;
+}
+
+.article-content-comment-container {
   display: flex;
-  justify-content: space-between;
+  flex-direction: row;
+  justify-content: end;
   align-items: center;
+  gap: 1rem;
+}
+.article-content-comment-container > * {
+  margin: 0;
+}
+.article-content-body-container,
+.article-content-body-container-collapse {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.article-content-body-container-collapse:hover {
+  cursor: pointer;
+  box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  transition: all 0.5s ease-in-out;
+}
+
+.article-content-comment-button {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* TOPICS - ARTICLES */
+
+.articles-container {
+  display: flex;
+  flex-direction: column;
+
+  gap: 5rem;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,29 +1,31 @@
 import React, { useEffect, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
-import Home from "./components/Home";
+import NavBarTopic from "./components/NavBarTopic";
 import Topic from "./components/Topic";
 import "./App.css";
+import ArticlePage from "./components/ArticlePage";
+import Sidebar from "./components/Sidebar";
 
 function App() {
   const [checkedTopics, setCheckedTopics] = useState([]);
 
   return (
-    <div>
+    <div className="App">
       <Header />
+      <Sidebar
+        checkedTopics={checkedTopics}
+        setCheckedTopics={setCheckedTopics}
+      />
       <Routes>
-        <Route
-          path="/"
-          element={
-            <Home
-              checkedTopics={checkedTopics}
-              setCheckedTopics={setCheckedTopics}
-            />
-          }
-        />
+        <Route path="/" element={<Topic checkedTopics={checkedTopics} />} />
         <Route
           path="/:topic_slug"
           element={<Topic checkedTopics={checkedTopics} />}
+        />
+        <Route
+          path="/:topic_slug/articles/:article_id"
+          element={<ArticlePage />}
         />
       </Routes>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,28 +1,18 @@
-import React, { useEffect, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
-import NavBarTopic from "./components/NavBarTopic";
 import Topic from "./components/Topic";
 import "./App.css";
 import ArticlePage from "./components/ArticlePage";
 import Sidebar from "./components/Sidebar";
 
 function App() {
-  const [checkedTopics, setCheckedTopics] = useState([]);
-
   return (
     <div className="App">
       <Header />
-      <Sidebar
-        checkedTopics={checkedTopics}
-        setCheckedTopics={setCheckedTopics}
-      />
+      <Sidebar />
       <Routes>
-        <Route path="/" element={<Topic checkedTopics={checkedTopics} />} />
-        <Route
-          path="/:topic_slug"
-          element={<Topic checkedTopics={checkedTopics} />}
-        />
+        <Route path="/" element={<Topic />} />
+        <Route path="/:topic_slug" element={<Topic />} />
         <Route
           path="/:topic_slug/articles/:article_id"
           element={<ArticlePage />}

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,30 @@
 import React, { useEffect, useState } from "react";
 import { Route, Routes } from "react-router-dom";
 import Header from "./components/Header";
-import NavBarTopic from "./components/NavBarTopic";
+import Home from "./components/Home";
 import Topic from "./components/Topic";
+import "./App.css";
 
 function App() {
+  const [checkedTopics, setCheckedTopics] = useState([]);
+
   return (
     <div>
       <Header />
-      <NavBarTopic />
       <Routes>
-        <Route path="/" element={<Topic />} />
-        <Route path="/:topic_slug" element={<Topic />} />
+        <Route
+          path="/"
+          element={
+            <Home
+              checkedTopics={checkedTopics}
+              setCheckedTopics={setCheckedTopics}
+            />
+          }
+        />
+        <Route
+          path="/:topic_slug"
+          element={<Topic checkedTopics={checkedTopics} />}
+        />
       </Routes>
     </div>
   );

--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -1,50 +1,87 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   BsFillArrowUpCircleFill,
   BsFillArrowDownCircleFill,
 } from "react-icons/bs";
+import { FcCollapse, FcExpand } from "react-icons/fc";
 import { AiOutlineComment } from "react-icons/ai";
 
 function Article({ props }) {
+  const {
+    article_id,
+    article_img_url,
+    author,
+    body,
+    comment_count,
+    created_at,
+    title,
+    topic,
+    votes,
+  } = props;
+
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
 
-  const handleArticleClick = () => {
+  const handleArticleBodyExpand = () => {
     setExpanded(!expanded);
   };
 
-  console.log(props);
+  const handleNavigateToArticle = () => {
+    navigate(`/${topic}/articles/${article_id}`);
+  };
 
   return (
-    <div className="article-container" onClick={handleArticleClick}>
-      <span className="article-votes-container">
+    <div className="article-container">
+      <span className="article-vote-container">
         <BsFillArrowUpCircleFill
           size={32}
           onClick={() => console.log("upvote")}
         />
-        <p>{props.votes}</p>
+        <p>{votes}</p>
         <BsFillArrowDownCircleFill
           size={32}
           onClick={() => console.log("downvote")}
         />
       </span>
-      <span className="article-content-container">
-        <span className="article-topic-title-created-container">
-          <h4>/{props.topic}</h4>
-          <p>Created at: {props.created_at}</p>
+      <div className="article-content-container">
+        <span className="article-content-title-container">
+          <h4>/{topic}</h4>
+          <h5>Author: {author}</h5>
+          <h5>Created at: {created_at}</h5>
+          <h5># {article_id}</h5>
         </span>
-        <h3>{props.title}</h3>
-        <img src={props.article_img_url} alt={props.title}></img>
-        <span className="article-author-comments-container">
-          <h5>Author: {props.author}</h5>
-          <h5>
-            {props.comment_count}
+        <h3>{title}</h3>
+        <img src={article_img_url} alt={title}></img>
+        <div className="article-content-body-container-collapse">
+          {expanded ? (
+            <span
+              className="article-content-body-container-collapse"
+              onClick={handleArticleBodyExpand}
+            >
+              <p>{body}</p>
+              <FcCollapse size={32} />
+            </span>
+          ) : (
+            <span
+              className="article-content-body-container-collapse"
+              onClick={handleArticleBodyExpand}
+            >
+              <p>{body.split(" ").slice(0, 10).join(" ")}...</p>
+              <FcExpand size={32} />
+            </span>
+          )}
+        </div>
+        <span className="article-content-comment-container">
+          <button
+            className="article-content-comment-button"
+            onClick={handleNavigateToArticle}
+          >
+            <h5>{comment_count} comments</h5>
             <AiOutlineComment size={32} />
-          </h5>
+          </button>
         </span>
-        <span className="article-body-container">
-          {expanded && <p>{props.body}</p>}
-        </span>
-      </span>
+      </div>
     </div>
   );
 }

--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import {
+  BsFillArrowUpCircleFill,
+  BsFillArrowDownCircleFill,
+} from "react-icons/bs";
+import { AiOutlineComment } from "react-icons/ai";
+
+function Article({ props }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleArticleClick = () => {
+    setExpanded(!expanded);
+  };
+
+  console.log(props);
+
+  return (
+    <div className="article-container" onClick={handleArticleClick}>
+      <span className="article-votes-container">
+        <BsFillArrowUpCircleFill
+          size={32}
+          onClick={() => console.log("upvote")}
+        />
+        <p>{props.votes}</p>
+        <BsFillArrowDownCircleFill
+          size={32}
+          onClick={() => console.log("downvote")}
+        />
+      </span>
+      <span className="article-content-container">
+        <span className="article-topic-title-created-container">
+          <h4>/{props.topic}</h4>
+          <p>Created at: {props.created_at}</p>
+        </span>
+        <h3>{props.title}</h3>
+        <img src={props.article_img_url} alt={props.title}></img>
+        <span className="article-author-comments-container">
+          <h5>Author: {props.author}</h5>
+          <h5>
+            {props.comment_count}
+            <AiOutlineComment size={32} />
+          </h5>
+        </span>
+        <span className="article-body-container">
+          {expanded && <p>{props.body}</p>}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default Article;

--- a/src/components/ArticlePage.jsx
+++ b/src/components/ArticlePage.jsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import api from "../utils/api";
+import {
+  BsFillArrowUpCircleFill,
+  BsFillArrowDownCircleFill,
+} from "react-icons/bs";
+
+function ArticlePage() {
+  let { article_id } = useParams();
+  const [article, setArticle] = useState({});
+
+  const {
+    article_img_url,
+    author,
+    body,
+    comment_count,
+    created_at,
+    title,
+    topic,
+    votes,
+  } = article;
+
+  useEffect(() => {
+    const fetchArticle = async () => {
+      const response = await api.get(`/articles/${article_id}`);
+      setArticle(response.data.article);
+    };
+
+    fetchArticle();
+  }, [article_id]);
+
+  return (
+    <div className="content">
+      <div className="article-container">
+        <span className="article-vote-container">
+          <BsFillArrowUpCircleFill
+            size={32}
+            onClick={() => console.log("upvote")}
+          />
+          <p>{votes}</p>
+          <BsFillArrowDownCircleFill
+            size={32}
+            onClick={() => console.log("downvote")}
+          />
+        </span>
+        <div className="article-content-container">
+          <span className="article-content-title-container">
+            <h4>/{topic}</h4>
+            <h5>Author: {author}</h5>
+            <h5>Created at: {created_at}</h5>
+            <h5># {article_id}</h5>
+          </span>
+          <h3>{title}</h3>
+          <img src={article_img_url} alt={title}></img>
+          <div className="article-content-body-container">
+            <p>{body}</p>
+          </div>
+          <span className="article-page-comment-container"></span>
+        </div>
+      </div>
+      <h1>This is where my comments go</h1>
+    </div>
+  );
+}
+
+export default ArticlePage;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,24 @@
-import React from "react";
+import React, { useContext } from "react";
+import { CheckboxContext } from "../contexts/CheckboxContext";
 
 function Header() {
+  const { checkedTopics } = useContext(CheckboxContext);
+  let title = "";
+  if (checkedTopics.length === 0) {
+    title = `NC-News/`;
+  } else if (checkedTopics.length === 1) {
+    title = `NC-News/${checkedTopics[0]}`;
+  } else if (checkedTopics.length > 1) {
+    let topics =
+      checkedTopics.slice(0, -1).join(", ") +
+      " and " +
+      checkedTopics[checkedTopics.length - 1];
+    title = `NC-News/${topics}`;
+  }
+
   return (
     <div className="header">
-      <h1>NC-News</h1>
+      <h1>{title}</h1>
       <h1>login</h1>
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,12 @@
 import React from "react";
 
 function Header() {
-  return <div>Header</div>;
+  return (
+    <div className="header">
+      <h1>NC-News</h1>
+      <h1>login</h1>
+    </div>
+  );
 }
 
 export default Header;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import NavBarTopic from "./NavBarTopic";
+import Topic from "./Topic";
+
+function Home({ checkedTopics, setCheckedTopics }) {
+  return (
+    <div>
+      <NavBarTopic
+        checkedTopics={checkedTopics}
+        setCheckedTopics={setCheckedTopics}
+      />
+      <Topic checkedTopics={checkedTopics} />
+    </div>
+  );
+}
+
+export default Home;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,15 +3,7 @@ import NavBarTopic from "./NavBarTopic";
 import Topic from "./Topic";
 
 function Home({ checkedTopics, setCheckedTopics }) {
-  return (
-    <div>
-      <NavBarTopic
-        checkedTopics={checkedTopics}
-        setCheckedTopics={setCheckedTopics}
-      />
-      <Topic checkedTopics={checkedTopics} />
-    </div>
-  );
+  return <div></div>;
 }
 
 export default Home;

--- a/src/components/NavBarTopic.jsx
+++ b/src/components/NavBarTopic.jsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { CheckboxContext } from "../contexts/CheckboxContext";
 import api from "../utils/api";
 
-function NavBarTopic({ checkedTopics, setCheckedTopics }) {
+function NavBarTopic() {
   const [topics, setTopics] = useState([]);
+  const { checkedTopics, setCheckedTopics } = useContext(CheckboxContext);
 
   const topicHandler = (topic) => {
     if (checkedTopics.includes(topic)) {

--- a/src/components/NavBarTopic.jsx
+++ b/src/components/NavBarTopic.jsx
@@ -1,30 +1,46 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import axios from "axios";
+import api from "../utils/api";
 
-function NavBarTopic() {
+function NavBarTopic({ checkedTopics, setCheckedTopics }) {
   const [topics, setTopics] = useState([]);
+
+  const topicHandler = (topic) => {
+    if (checkedTopics.includes(topic)) {
+      setCheckedTopics(
+        checkedTopics.filter((checkedTopic) => checkedTopic !== topic)
+      );
+    } else {
+      setCheckedTopics([...checkedTopics, topic]);
+    }
+  };
 
   useEffect(() => {
     const fetchTopics = async () => {
-      const response = await axios.get(
-        "https://nc-news-6g30.onrender.com/api/topics"
-      );
+      const response = await api.get(`/topics`);
       setTopics(response.data.topics);
     };
 
     fetchTopics();
   }, []);
+
   return (
     <div>
-      <h2>Topics</h2>
+      <h2>Topic Sort</h2>
       <ul>
-        <li>
-          <Link to={`/`}>All</Link>
-        </li>
         {topics.map((topic, index) => (
           <li key={index}>
-            <Link to={`/${topic.slug}`}>{topic.slug}</Link>
+            <input
+              type="checkbox"
+              id={topic.slug}
+              value={topic.slug}
+              checked={checkedTopics.includes(topic.slug)}
+              onChange={() => topicHandler(topic.slug)}
+            />
+            <label htmlFor={topic.slug}>
+              <Link to={topic.slug}>{topic.slug}</Link>
+            </label>
           </li>
         ))}
       </ul>

--- a/src/components/NavBarTopic.jsx
+++ b/src/components/NavBarTopic.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import axios from "axios";
 import api from "../utils/api";
 
 function NavBarTopic({ checkedTopics, setCheckedTopics }) {
@@ -16,19 +15,45 @@ function NavBarTopic({ checkedTopics, setCheckedTopics }) {
     }
   };
 
+  const topicLinkHandler = (topic) => {
+    setCheckedTopics([topic]);
+  };
+
   useEffect(() => {
     const fetchTopics = async () => {
-      const response = await api.get(`/topics`);
-      setTopics(response.data.topics);
+      try {
+        const response = await api.get(`/topics`);
+        setTopics(response.data.topics);
+      } catch (err) {
+        console.log(err);
+      }
     };
 
     fetchTopics();
   }, []);
 
   return (
-    <div>
+    <>
       <h2>Topic Sort</h2>
       <ul>
+        <li>
+          <input
+            type="checkbox"
+            id="All"
+            checked={checkedTopics.length === 0}
+            onChange={() => setCheckedTopics([])}
+          />
+          <label htmlFor="All">
+            <Link
+              onClick={() => {
+                setCheckedTopics([]);
+              }}
+              to="/"
+            >
+              All
+            </Link>
+          </label>
+        </li>
         {topics.map((topic, index) => (
           <li key={index}>
             <input
@@ -39,12 +64,17 @@ function NavBarTopic({ checkedTopics, setCheckedTopics }) {
               onChange={() => topicHandler(topic.slug)}
             />
             <label htmlFor={topic.slug}>
-              <Link to={topic.slug}>{topic.slug}</Link>
+              <Link
+                onClick={() => topicLinkHandler(topic.slug)}
+                to={topic.slug}
+              >
+                {topic.slug}
+              </Link>
             </label>
           </li>
         ))}
       </ul>
-    </div>
+    </>
   );
 }
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import NavBarTopic from "./NavBarTopic";
+
+function Sidebar({ checkedTopics, setCheckedTopics }) {
+  return (
+    <div className="sidebar">
+      <NavBarTopic
+        checkedTopics={checkedTopics}
+        setCheckedTopics={setCheckedTopics}
+      />
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,13 +1,10 @@
 import React from "react";
 import NavBarTopic from "./NavBarTopic";
 
-function Sidebar({ checkedTopics, setCheckedTopics }) {
+function Sidebar() {
   return (
     <div className="sidebar">
-      <NavBarTopic
-        checkedTopics={checkedTopics}
-        setCheckedTopics={setCheckedTopics}
-      />
+      <NavBarTopic />
     </div>
   );
 }

--- a/src/components/Topic.jsx
+++ b/src/components/Topic.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import api from "../utils/api";
 import Article from "./Article";
+import NavBarTopic from "./NavBarTopic";
 
 function Topic({ checkedTopics }) {
   let { topic_slug } = useParams();
@@ -9,37 +10,38 @@ function Topic({ checkedTopics }) {
 
   useEffect(() => {
     const fetchArticles = async () => {
-      let topics;
-      if (topic_slug) {
-        topics = topic_slug;
-      } else {
-        topics = checkedTopics.join(",");
-      }
+      try {
+        let topics;
+        if (topic_slug) {
+          topics = topic_slug;
+        } else {
+          topics = checkedTopics.join(",");
+        }
 
-      const response = await api.get(`/articles`, {
-        params: {
-          topic: topics,
-        },
-      });
-      setArticles(response.data.articles);
+        const response = await api.get(`/articles`, {
+          params: {
+            topic: topics,
+          },
+        });
+        setArticles(response.data.articles);
+      } catch (err) {
+        console.log(err);
+      }
     };
 
     fetchArticles();
   }, [checkedTopics, topic_slug]);
 
   return (
-    <div>
+    <div className="content">
       {topic_slug ? (
         <h2>{topic_slug}</h2>
       ) : (
         <h2>{checkedTopics.join(" & ")}</h2>
       )}
-
-      <ul>
-        {articles.map((article) => (
-          <Article key={article.article_id} props={article} />
-        ))}
-      </ul>
+      {articles.map((article, index) => (
+        <Article props={article} key={index} />
+      ))}
     </div>
   );
 }

--- a/src/components/Topic.jsx
+++ b/src/components/Topic.jsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useParams } from "react-router-dom";
+import { CheckboxContext } from "../contexts/CheckboxContext";
 import api from "../utils/api";
 import Article from "./Article";
-import NavBarTopic from "./NavBarTopic";
 
-function Topic({ checkedTopics }) {
+function Topic() {
   let { topic_slug } = useParams();
   const [articles, setArticles] = useState([]);
+  const { checkedTopics } = useContext(CheckboxContext);
 
   useEffect(() => {
     const fetchArticles = async () => {
@@ -34,11 +35,6 @@ function Topic({ checkedTopics }) {
 
   return (
     <div className="content">
-      {topic_slug ? (
-        <h2>{topic_slug}</h2>
-      ) : (
-        <h2>{checkedTopics.join(" & ")}</h2>
-      )}
       {articles.map((article, index) => (
         <Article props={article} key={index} />
       ))}

--- a/src/components/Topic.jsx
+++ b/src/components/Topic.jsx
@@ -1,28 +1,43 @@
 import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import axios from "axios";
+import api from "../utils/api";
+import Article from "./Article";
 
-function Topic() {
+function Topic({ checkedTopics }) {
   let { topic_slug } = useParams();
-  if (topic_slug === undefined) topic_slug = "";
   const [articles, setArticles] = useState([]);
 
   useEffect(() => {
     const fetchArticles = async () => {
-      const response = await axios.get(
-        `https://nc-news-6g30.onrender.com/api/articles?topic=${topic_slug}`
-      );
+      let topics;
+      if (topic_slug) {
+        topics = topic_slug;
+      } else {
+        topics = checkedTopics.join(",");
+      }
+
+      const response = await api.get(`/articles`, {
+        params: {
+          topic: topics,
+        },
+      });
       setArticles(response.data.articles);
     };
 
     fetchArticles();
-  }, [topic_slug]);
+  }, [checkedTopics, topic_slug]);
+
   return (
     <div>
-      {topic_slug ? <h2>Topic {topic_slug}</h2> : <h2>All Topics</h2>}
+      {topic_slug ? (
+        <h2>{topic_slug}</h2>
+      ) : (
+        <h2>{checkedTopics.join(" & ")}</h2>
+      )}
+
       <ul>
         {articles.map((article) => (
-          <li key={article.article_id}>{article.title}</li>
+          <Article key={article.article_id} props={article} />
         ))}
       </ul>
     </div>

--- a/src/contexts/CheckboxContext.jsx
+++ b/src/contexts/CheckboxContext.jsx
@@ -1,0 +1,15 @@
+import React, { useState, createContext } from "react";
+
+const CheckboxContext = createContext();
+
+const CheckboxProvider = (props) => {
+  const [checkedTopics, setCheckedTopics] = useState([]);
+
+  return (
+    <CheckboxContext.Provider value={{ checkedTopics, setCheckedTopics }}>
+      {props.children}
+    </CheckboxContext.Provider>
+  );
+};
+
+export { CheckboxContext, CheckboxProvider };

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { BrowserRouter } from "react-router-dom";
+import { CheckboxProvider } from "./contexts/CheckboxContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <CheckboxProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </CheckboxProvider>
 );

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://nc-news-6g30.onrender.com/api/",
+});
+
+export default api;


### PR DESCRIPTION
Theres a massive chunk of repeated code in the articles and the article page. Im not sure how to get it DRY whilst still retaining the interface i want. However, if someone links to a specific article it will need to perform the get request anyway.

From the home page, you can click the checkboxes next to the topic name to include articles from that topic. Im happy with this functionality.

You can click the link next to the checkbox to go directly to that topic page. You can play with the checkboxes here and it does nothing so I need to disable them.

I think ill add a check to see if the user is on the home path "/" , if they arnt then disable the checkboxes but leave the links.